### PR TITLE
fix: use type-only imports for verbatimModuleSyntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tamtamchik/json-deep-sort",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tamtamchik/json-deep-sort",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tamtamchik/json-deep-sort",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A comprehensive utility for sorting JSON objects by keys.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/array-sorter.ts
+++ b/src/array-sorter.ts
@@ -1,4 +1,4 @@
-import { SortOptions } from './types';
+import type { SortOptions } from './types';
 import { isSortablePrimitive, hasNullishValues } from './type-guards';
 import { compareSortablePrimitives } from './comparators';
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import { SortOptions } from './types';
+import type { SortOptions } from './types';
 import { isPrimitive, isNonSortableObject, isObject } from './type-guards';
 import { sortArray } from './array-sorter';
 import { sortObject } from './object-sorter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { SortOptions } from './types';
+import type { SortOptions } from './types';
 import { sortRecursively } from './core';
 
 export function sort<T>(

--- a/src/object-sorter.ts
+++ b/src/object-sorter.ts
@@ -1,4 +1,4 @@
-import { SortOptions, ObjectType, SortedEntry } from './types';
+import type { SortOptions, ObjectType, SortedEntry } from './types';
 import { compareObjectKeys } from './comparators';
 
 export function sortObject(obj: ObjectType, options: SortOptions): ObjectType {

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -1,10 +1,5 @@
-import {
-  NULLISH_VALUES,
-  SORTABLE_PRIMITIVE_TYPES,
-  NullishValue,
-  NonSortableType,
-  ObjectType,
-} from './types';
+import { NULLISH_VALUES, SORTABLE_PRIMITIVE_TYPES } from './types';
+import type { NullishValue, NonSortableType, ObjectType } from './types';
 
 // Type guards - single responsibility, clear naming
 export function isNullish(value: unknown): value is NullishValue {


### PR DESCRIPTION
## Summary
- Use `import type` for all type-only imports across source files
- Fixes errors when consumers enable `verbatimModuleSyntax` in their tsconfig

Closes #5

## Test plan
- [x] `npm run build` — CJS + ESM output
- [x] `npm test` — 66/66 pass
- [x] `npm run lint` — clean