### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format


### PR DESCRIPTION
Potential fix for [https://github.com/tamtamchik/json-deep-sort/security/code-scanning/3](https://github.com/tamtamchik/json-deep-sort/security/code-scanning/3)

Add a workflow-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token access.  
Best fix (without changing functionality): insert:

```yml
permissions:
  contents: read
```

near the top-level keys (after `on:` block and before `jobs:` is typical). This is sufficient for `actions/checkout` and read-only CI tasks, and avoids granting write scopes unnecessarily. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
