### PR TITLE
Add Context7 configuration

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "JSON Deep Sort",
+  "description": "A comprehensive utility for recursively sorting JSON objects by keys, producing deterministic output for clean git diffs, hashing, and comparison.",
+  "folders": [],
+  "excludeFolders": ["src", "test"],
+  "excludeFiles": [],
+  "rules": [
+    "Sorting is recursive: nested objects and objects inside arrays are sorted too",
+    "Use it to make generated JSON deterministic so git diffs stay clean"
+  ]
+}

--- a/context7.json
+++ b/context7.json
@@ -6,7 +6,7 @@
   "excludeFolders": ["src", "test"],
   "excludeFiles": [],
   "rules": [
-    "Sorting is recursive: nested objects and objects inside arrays are sorted too",
-    "Use it to make generated JSON deterministic so git diffs stay clean"
+    "Expect recursive sorting: nested objects and objects inside arrays are sorted too",
+    "Use sort() to make generated JSON deterministic so git diffs stay clean"
   ]
 }

--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/tamtamchik/json-deep-sort",
+  "public_key": "pk_QlHk4oryApIHWteupSUUF",
   "projectTitle": "JSON Deep Sort",
   "description": "A comprehensive utility for recursively sorting JSON objects by keys, producing deterministic output for clean git diffs, hashing, and comparison.",
   "folders": [],

--- a/context7.json
+++ b/context7.json
@@ -6,7 +6,8 @@
   "excludeFolders": ["src", "test"],
   "excludeFiles": [],
   "rules": [
-    "Expect recursive sorting: nested objects and objects inside arrays are sorted too",
-    "Use sort() to make generated JSON deterministic so git diffs stay clean"
+    "Pass sortPrimitiveArrays=true as the third argument to sort primitive arrays; by default only object keys are sorted and array order is preserved",
+    "Pass false as the second argument for descending order",
+    "sort() returns a new structure without mutating the input; Date, RegExp, Map, Set and other non-plain objects are returned untouched"
   ]
 }

--- a/context7.json
+++ b/context7.json
@@ -8,6 +8,9 @@
   "rules": [
     "Pass sortPrimitiveArrays=true as the third argument to sort primitive arrays; by default only object keys are sorted and array order is preserved",
     "Pass false as the second argument for descending order",
-    "sort() returns a new structure without mutating the input; Date, RegExp, Map, Set and other non-plain objects are returned untouched"
+    "sort() returns a new structure without mutating the input; Date, RegExp, Map, Set and other non-plain objects are returned untouched",
+    "Expect arrays containing null or undefined to keep their order even with sortPrimitiveArrays=true",
+    "Expect mixed-type primitive arrays to keep their order; only same-type arrays are sorted",
+    "Expect string keys to be compared with localeCompare and symbol keys to be placed after string keys"
   ]
 }


### PR DESCRIPTION
Adds a `context7.json` so Context7 indexes the README with the right title, description, and usage rules when the library is submitted to https://context7.com.