### PR TITLE
Remove stale async claim from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ JSON Deep Sort is a powerful and versatile TypeScript package designed for effic
 
 - Comprehensive handling of deeply nested objects and arrays
 - Flexible sorting options, including ascending and descending order
-- Support for both synchronous and asynchronous operations
+- Optional sorting of primitive arrays
 - Preservation of non-sortable objects (e.g., Date, RegExp, Function)
 - Lightweight implementation with zero dependencies
 


### PR DESCRIPTION
The README advertised "Support for both synchronous and asynchronous operations", but the package exports only the synchronous `sort()` — the only Promise-related behavior is that Promise instances are treated as non-sortable values. Replaces the bullet with an actual feature: optional primitive array sorting via `sortPrimitiveArrays`.