### PR TITLE
Switch Dependabot to monthly checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 2
     cooldown:
       default-days: 7
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7


### PR DESCRIPTION
npm and github-actions updates move from weekly to monthly; cooldown stays at 7 days.